### PR TITLE
add support for menu in blender 280

### DIFF
--- a/pyblish_blender/lib.py
+++ b/pyblish_blender/lib.py
@@ -147,12 +147,12 @@ def pyblish_menu_draw(self, context):
 
 
 def add_to_filemenu():
-    bpy.types.INFO_MT_file.append(pyblish_menu_draw)
+    bpy.types.TOPBAR_MT_file.append(pyblish_menu_draw)
 
 
 def remove_from_filemenu():
     """Remove Pyblish from file menu"""
-    bpy.types.INFO_MT_file.remove(pyblish_menu_draw)
+    bpy.types.TOPBAR_MT_file.remove(pyblish_menu_draw)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
updated menu to work with blender 280
otherwise you get an error when running setup()
and pyblish wont show in menu